### PR TITLE
Allow setting display name for servers

### DIFF
--- a/src/main/java/net/william278/velocitab/config/Placeholder.java
+++ b/src/main/java/net/william278/velocitab/config/Placeholder.java
@@ -23,7 +23,7 @@ public enum Placeholder {
     CURRENT_DATE((plugin, player) -> DateTimeFormatter.ofPattern("dd MMM yyyy").format(LocalDateTime.now())),
     CURRENT_TIME((plugin, player) -> DateTimeFormatter.ofPattern("HH:mm:ss").format(LocalDateTime.now())),
     USERNAME((plugin, player) -> plugin.getFormatter().escape(player.getPlayer().getUsername())),
-    SERVER((plugin, player) -> player.getServerName()),
+    SERVER((plugin, player) -> player.getServerDisplayName(plugin)),
     PING((plugin, player) -> Long.toString(player.getPlayer().getPing())),
     PREFIX((plugin, player) -> player.getRole().getPrefix().orElse("")),
     SUFFIX((plugin, player) -> player.getRole().getSuffix().orElse("")),

--- a/src/main/java/net/william278/velocitab/config/Settings.java
+++ b/src/main/java/net/william278/velocitab/config/Settings.java
@@ -56,6 +56,12 @@ public class Settings {
     @YamlComment("Only show other players on a server that is part of the same server group as the player.")
     private boolean onlyListPlayersInSameGroup = true;
 
+    @Getter
+    @YamlKey("server_display_names")
+    @YamlComment("Define custom names to be shown in the TAB list for specific server names.\n" +
+                 "If no custom display name is provided for a server, its original name will be used.")
+    private Map<String, String> serverDisplayNames = Map.of("very-long-server-name", "VLSN");
+
     @YamlKey("enable_papi_hook")
     private boolean enablePapiHook = true;
 
@@ -108,6 +114,17 @@ public class Settings {
     public String getFormat(@NotNull String serverGroup) {
         return StringEscapeUtils.unescapeJava(
                 formats.getOrDefault(serverGroup, "%username%"));
+    }
+
+    /**
+     * Get display name for the server
+     *
+     * @param serverName The server name
+     * @return The display name, or the server name if no display name is defined
+     */
+    @NotNull
+    public String getServerDisplayName(@NotNull String serverName) {
+        return serverDisplayNames.getOrDefault(serverName, serverName);
     }
 
     /**

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -34,11 +34,29 @@ public final class TabPlayer implements Comparable<TabPlayer> {
         return role;
     }
 
+    /**
+     * Get the server name the player is currently on.
+     * Isn't affected by server aliases defined in the config.
+     *
+     * @return The server name
+     */
     @NotNull
     public String getServerName() {
         return player.getCurrentServer()
                 .map(serverConnection -> serverConnection.getServerInfo().getName())
                 .orElse("unknown");
+    }
+
+    /**
+     * Get the display name of the server the player is currently on.
+     * Affected by server aliases defined in the config.
+     *
+     * @param plugin The plugin instance
+     * @return The display name of the server
+     */
+    @NotNull
+    public String getServerDisplayName(@NotNull Velocitab plugin) {
+        return plugin.getSettings().getServerDisplayName(getServerName());
     }
 
     @NotNull


### PR DESCRIPTION
Adds a mapping for server aliases in the config and uses that mapping for `%server%` placeholder replacements.

Introduced another method in `TabPlayer` instead of altering `getServerName` since it's used in several places where display names don't seem like a reasonable thing to expect (per-server-group headers/footers, sorting).

Preview:
![server alias](https://user-images.githubusercontent.com/49086127/229106896-db1b3523-e77e-4c74-ad35-f500c4daf669.png)

Closes #27