### PR TITLE
Support legacy RGB color codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Simply download the latest release and place it in your Velocity plugins folder 
 Velocitab has a simple config file that lets you define a header, footer and format for the player list. You can additionally configure [groups of servers](https://william278.net/docs/velocitab/server-groups) to display different formats in the TAB menu depending on which server the player is viewing it from.
 
 ### Formatting
-Velocitab [supports](https://william278.net/docs/velocitab/formatting) the full range of RGB colors and gradients, with options to use either MineDown (_default_) or MiniMessage formatting.
+Velocitab [supports](https://william278.net/docs/velocitab/formatting) the full range of RGB colors and gradients, with options to use either MineDown (_default_), MiniMessage, or legacy formatting.
 
 ### Placeholders
 You can include [placeholders](https://william278.net/docs/velocitab/placeholders) in the header, footer and player name format of the TAB list. The following placeholders are supported:

--- a/src/main/java/net/william278/velocitab/config/Formatter.java
+++ b/src/main/java/net/william278/velocitab/config/Formatter.java
@@ -3,6 +3,7 @@ package net.william278.velocitab.config;
 import de.themoep.minedown.adventure.MineDown;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.william278.velocitab.Velocitab;
 import net.william278.velocitab.player.TabPlayer;
 import org.apache.commons.lang3.function.TriFunction;
@@ -20,7 +21,9 @@ public enum Formatter {
     MINIMESSAGE((text, player, plugin) -> plugin.getMiniPlaceholdersHook()
             .map(hook -> hook.format(text, player.getPlayer()))
             .orElse(MiniMessage.miniMessage().deserialize(text)),
-            (text) -> MiniMessage.miniMessage().escapeTags(text));
+            (text) -> MiniMessage.miniMessage().escapeTags(text)),
+    LEGACY((text, player, plugin) -> LegacyComponentSerializer.legacyAmpersand().deserialize(text),
+            Function.identity());
 
     /**
      * Function to apply formatting to a string

--- a/src/main/java/net/william278/velocitab/config/Settings.java
+++ b/src/main/java/net/william278/velocitab/config/Settings.java
@@ -32,7 +32,7 @@ public class Settings {
     private Map<String, String> formats = Map.of("default", "&7[%server%] &f%prefix%%username%");
 
     @Getter
-    @YamlComment("Which text formatter to use (MINEDOWN or MINIMESSAGE)")
+    @YamlComment("Which text formatter to use (MINEDOWN, MINIMESSAGE, or LEGACY)")
     @YamlKey("formatting_type")
     private Formatter formatter = Formatter.MINEDOWN;
 


### PR DESCRIPTION
I'm not sure if you'd be willing to accept this: I will totally understand if this is something you don't want to support!

I have a bunch of these color codes on my server used in prefixes/suffixes and can't easily switch them over, plus I saw some messages in Discord that asked about similar option (although many of them were related to HuskChat, so not an apples to apples comparison).

---

Uses Adventure's leagacy serializer under the hood to parse Adventure-like (`&#a25981`) and BungeeCord-like (`&x&a&2&5&9&8&1`) RGB color codes.

I can't propose changes to wiki, but I was thinking of blurb like this that would be added at the bottom of [Formatting](https://github.com/WiIIiam278/Velocitab/wiki/Formatting):
```
## Legacy formatting

⚠️ Option for legacy formatting is provided only for backwards compatibility with other plugins, please consider using MineDown or MiniMessage options instead!

Legacy formatting can be enabled by setting `formatting_type` to `LEGACY` in `config.yml`. Legacy formatter supports Mojang color and formatting codes (e.g. `&d`, `&l`), Adventure-styled RGB color codes (e.g. `&#a25981`), as well as BungeeCord RGB color codes (e.g. `&x&a&2&5&9&8&1`). See the [LegacyComponentSerializer Syntax Reference](https://docs.advntr.dev/serializer/legacy.html) on the Adventure Docs for more technical details.
```
