### PR TITLE
Handle ProtocolizePlayer absence before sending packets

### DIFF
--- a/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
+++ b/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
@@ -4,6 +4,7 @@ import com.velocitypowered.api.proxy.Player;
 import dev.simplix.protocolize.api.PacketDirection;
 import dev.simplix.protocolize.api.Protocol;
 import dev.simplix.protocolize.api.Protocolize;
+import dev.simplix.protocolize.api.player.ProtocolizePlayer;
 import net.william278.velocitab.Velocitab;
 import org.jetbrains.annotations.NotNull;
 
@@ -54,7 +55,12 @@ public class ScoreboardManager {
 
     private void dispatchPacket(@NotNull UpdateTeamsPacket packet, @NotNull Player player) {
         try {
-            Protocolize.playerProvider().player(player.getUniqueId()).sendPacket(packet);
+            ProtocolizePlayer protocolizePlayer = Protocolize.playerProvider().player(player.getUniqueId());
+            if (protocolizePlayer != null) {
+                protocolizePlayer.sendPacket(packet);
+            } else {
+                plugin.log("Failed to get ProtocolizePlayer for player " + player.getUsername() + " (UUID: " + player.getUniqueId() + ")");
+            }
         } catch (Exception e) {
             plugin.log("Failed to dispatch packet (is the client or server modded or using an illegal version?)", e);
         }


### PR DESCRIPTION
Ran into an error when a player gets kicked by a plugin upon joining, or when they experience client-side issues and disconnect immediately after joining:

```
[22:45:26] [Netty epoll Worker #28/INFO] [com.velocitypowered.proxy.connection.MinecraftConnection]: [server connection] XQR -> oneblock has connected
[22:45:26] [Netty epoll Worker #28/INFO] [com.velocitypowered.proxy.connection.MinecraftConnection]: [connected player] XQR (/**.**.**.**:25565) has disconnected
[22:45:26] [Netty epoll Worker #28/INFO] [com.velocitypowered.proxy.connection.MinecraftConnection]: [server connection] XQR -> oneblock has disconnected
[22:45:27] [Velocity Task Scheduler - #16/ERROR] [velocitab]: Failed to dispatch packet (is the client or server modded or using an illegal version?)
java.lang.NullPointerException: Cannot invoke "dev.simplix.protocolize.api.player.ProtocolizePlayer.sendPacket(Object)" because the return value of "dev.simplix.protocolize.api.providers.ProtocolizePlayerProvider.player(java.util.UUID)" is null
        at net.william278.velocitab.packet.ScoreboardManager.dispatchPacket(ScoreboardManager.java:57) ~[?:?]
        at net.william278.velocitab.packet.ScoreboardManager.updateRoles(ScoreboardManager.java:50) ~[?:?]
        at net.william278.velocitab.tab.PlayerTabList.lambda$updatePlayer$17(PlayerTabList.java:166) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:757) ~[?:?]
        at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:735) ~[?:?]
        at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2182) ~[?:?]
        at net.william278.velocitab.tab.PlayerTabList.lambda$updatePlayer$18(PlayerTabList.java:162) ~[?:?]
        at java.util.concurrent.ConcurrentLinkedQueue.forEachFrom(ConcurrentLinkedQueue.java:1037) ~[?:?]
        at java.util.concurrent.ConcurrentLinkedQueue.forEach(ConcurrentLinkedQueue.java:1054) ~[?:?]
        at net.william278.velocitab.tab.PlayerTabList.updatePlayer(PlayerTabList.java:162) ~[?:?]
        at net.william278.velocitab.tab.PlayerTabList.lambda$updatePeriodically$21(PlayerTabList.java:195) ~[?:?]
        at java.util.concurrent.ConcurrentLinkedQueue.forEachFrom(ConcurrentLinkedQueue.java:1037) ~[?:?]
        at java.util.concurrent.ConcurrentLinkedQueue.forEach(ConcurrentLinkedQueue.java:1054) ~[?:?]
        at net.william278.velocitab.tab.PlayerTabList.lambda$updatePeriodically$22(PlayerTabList.java:194) ~[?:?]
        at com.velocitypowered.proxy.scheduler.VelocityScheduler$VelocityTask.lambda$run$1(VelocityScheduler.java:242) ~[velocity-3.2.0-SNAPSHOT-247.jar:3.2.0-SNAPSHOT (git-6a125bd0-b247)]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
```

This error then gets spammed in the console, cluttering the logs.

I've added a check for `ProtocolizePlayer` before attempting to send a packet: that seemed like a straightforward fix, but let me know if I'm missing something!
