### PR TITLE
Handle DisconnectEvent only if login status is SUCCESSFUL_LOGIN

### DIFF
--- a/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
+++ b/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
@@ -153,6 +153,8 @@ public class PlayerTabList {
 
     @Subscribe
     public void onPlayerQuit(@NotNull DisconnectEvent event) {
+        if (event.getLoginStatus() != DisconnectEvent.LoginStatus.SUCCESSFUL_LOGIN) return;
+
         // Remove the player from the tracking list, Print warning if player was not removed
         if (!players.removeIf(player -> player.getPlayer().getUniqueId().equals(event.getPlayer().getUniqueId()))) {
             plugin.log("Failed to remove disconnecting player " + event.getPlayer().getUsername() + " (UUID: " + event.getPlayer().getUniqueId() + ")");


### PR DESCRIPTION
If player is online and this player will try to join from another client, DisconnectEvent will be fired with login status CONFLICTING_LOGIN. So we need to check if login status is SUCCESSFUL_LOGIN, otherwise player will be removed from the tablist