### PR TITLE
Added function to unregister packets on plugin disable. [Dev System Only]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     compileOnly 'net.luckperms:api:5.4'
     compileOnly 'io.github.miniplaceholders:miniplaceholders-api:2.0.0'
     compileOnly 'net.william278:PAPIProxyBridge:1.3'
+    compileOnly 'it.unimi.dsi:fastutil:8.5.12'
+
 
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'net.william278:annotaml:2.0.7'

--- a/src/main/java/net/william278/velocitab/Velocitab.java
+++ b/src/main/java/net/william278/velocitab/Velocitab.java
@@ -156,7 +156,7 @@ public class Velocitab {
     }
 
     private void disableScoreboardManager() {
-if (scoreboardManager !=null && settings.isSortPlayers()) {
+        if (scoreboardManager !=null && settings.isSortPlayers()) {
             scoreboardManager.unregisterPacket();
         }
     }

--- a/src/main/java/net/william278/velocitab/Velocitab.java
+++ b/src/main/java/net/william278/velocitab/Velocitab.java
@@ -23,6 +23,7 @@ import com.google.inject.Inject;
 import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.PluginDescription;
@@ -91,6 +92,12 @@ public class Velocitab {
         logger.info("Successfully enabled Velocitab");
     }
 
+    @Subscribe
+    public void onProxyShutdown(@NotNull ProxyShutdownEvent event) {
+        disableScoreboardManager();
+        logger.info("Successfully disabled Velocitab");
+    }
+
     @NotNull
     public ProxyServer getServer() {
         return server;
@@ -145,6 +152,12 @@ public class Velocitab {
         if (settings.isSortPlayers()) {
             this.scoreboardManager = new ScoreboardManager(this);
             scoreboardManager.registerPacket();
+        }
+    }
+
+    private void disableScoreboardManager() {
+        if(scoreboardManager!=null && settings.isSortPlayers()) {
+            scoreboardManager.unregisterPacket();
         }
     }
 

--- a/src/main/java/net/william278/velocitab/Velocitab.java
+++ b/src/main/java/net/william278/velocitab/Velocitab.java
@@ -156,7 +156,7 @@ public class Velocitab {
     }
 
     private void disableScoreboardManager() {
-        if(scoreboardManager!=null && settings.isSortPlayers()) {
+if (scoreboardManager !=null && settings.isSortPlayers()) {
             scoreboardManager.unregisterPacket();
         }
     }

--- a/src/main/java/net/william278/velocitab/packet/PacketRegistration.java
+++ b/src/main/java/net/william278/velocitab/packet/PacketRegistration.java
@@ -78,7 +78,6 @@ public final class PacketRegistration<P extends MinecraftPacket> {
         }
 
         public void register() {
-
             try {
                 final StateRegistry.PacketRegistry packetRegistry = direction == ProtocolUtils.Direction.CLIENTBOUND
                         ? (StateRegistry.PacketRegistry) STATE_REGISTRY$clientBound.invoke(stateRegistry)
@@ -99,7 +98,6 @@ public final class PacketRegistration<P extends MinecraftPacket> {
         @SuppressWarnings("unchecked")
         public void unregister() {
             try {
-
                 final StateRegistry.PacketRegistry packetRegistry = direction == ProtocolUtils.Direction.CLIENTBOUND
                         ? (StateRegistry.PacketRegistry) STATE_REGISTRY$clientBound.invoke(stateRegistry)
                         : (StateRegistry.PacketRegistry) STATE_REGISTRY$serverBound.invoke(stateRegistry);

--- a/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
+++ b/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
@@ -34,6 +34,7 @@ import static com.velocitypowered.api.network.ProtocolVersion.*;
 
 public class ScoreboardManager {
 
+    private PacketRegistration<UpdateTeamsPacket> packetRegistration;
     private final Velocitab plugin;
     private final Map<UUID, List<String>> createdTeams;
     private final Map<UUID, Map<String, String>> roleMappings;
@@ -98,7 +99,7 @@ public class ScoreboardManager {
 
     public void registerPacket() {
         try {
-            PacketRegistration.of(UpdateTeamsPacket.class)
+            packetRegistration = PacketRegistration.of(UpdateTeamsPacket.class)
                     .direction(ProtocolUtils.Direction.CLIENTBOUND)
                     .packetSupplier(UpdateTeamsPacket::new)
                     .stateRegistry(StateRegistry.PLAY)
@@ -108,10 +109,18 @@ public class ScoreboardManager {
                     .mapping(0x55, MINECRAFT_1_17, false)
                     .mapping(0x58, MINECRAFT_1_19_1, false)
                     .mapping(0x56, MINECRAFT_1_19_3, false)
-                    .mapping(0x5A, MINECRAFT_1_19_4, false)
-                    .register();
+                    .mapping(0x5A, MINECRAFT_1_19_4, false);
+            packetRegistration.register();
         } catch (Throwable e) {
             plugin.log(Level.ERROR, "Failed to register UpdateTeamsPacket", e);
+        }
+    }
+
+    public void unregisterPacket() {
+        try {
+            packetRegistration.unregister();
+        } catch (Throwable e) {
+            plugin.log(Level.ERROR, "Failed to unregister UpdateTeamsPacket", e);
         }
     }
 

--- a/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
+++ b/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
@@ -117,6 +117,9 @@ public class ScoreboardManager {
     }
 
     public void unregisterPacket() {
+        if(packetRegistration==null) {
+            return;
+        }
         try {
             packetRegistration.unregister();
         } catch (Throwable e) {


### PR DESCRIPTION
While testing and updating Velocitab, restarting the proxy could take a while. With this pr I unregister packets when the plugin disable, so with a plugin manager it's possibile to register team packets again.