### PR TITLE
Added support for nametags and fixed a few problems

### DIFF
--- a/src/main/java/net/william278/velocitab/Velocitab.java
+++ b/src/main/java/net/william278/velocitab/Velocitab.java
@@ -95,6 +95,7 @@ public class Velocitab {
     @Subscribe
     public void onProxyShutdown(@NotNull ProxyShutdownEvent event) {
         disableScoreboardManager();
+        getLuckPermsHook().ifPresent(LuckPermsHook::close);
         logger.info("Successfully disabled Velocitab");
     }
 
@@ -182,6 +183,10 @@ public class Velocitab {
                 getLuckPermsHook().map(hook -> hook.getPlayerRole(player)).orElse(Role.DEFAULT_ROLE),
                 getLuckPermsHook().map(LuckPermsHook::getHighestWeight).orElse(0)
         );
+    }
+
+    public Optional<TabPlayer> getTabPlayer(String name) {
+        return server.getPlayer(name).map(this::getTabPlayer);
     }
 
     private void registerCommands() {

--- a/src/main/java/net/william278/velocitab/Velocitab.java
+++ b/src/main/java/net/william278/velocitab/Velocitab.java
@@ -120,6 +120,12 @@ public class Velocitab {
                     new File(dataDirectory.toFile(), "config.yml"),
                     new Settings(this)
             ).get();
+
+            settings.getNametags().values().stream()
+                    .filter(nametag -> !nametag.contains("%username%")).forEach(nametag -> {
+                        logger.warn("Nametag '" + nametag + "' does not contain %username% - removing");
+                        settings.getNametags().remove(nametag);
+                    });
         } catch (IOException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
             logger.error("Failed to load config file: " + e.getMessage(), e);
         }
@@ -157,7 +163,7 @@ public class Velocitab {
     }
 
     private void disableScoreboardManager() {
-        if (scoreboardManager !=null && settings.isSortPlayers()) {
+        if (scoreboardManager != null && settings.isSortPlayers()) {
             scoreboardManager.unregisterPacket();
         }
     }

--- a/src/main/java/net/william278/velocitab/config/Formatter.java
+++ b/src/main/java/net/william278/velocitab/config/Formatter.java
@@ -81,7 +81,7 @@ public enum Formatter {
 
     @NotNull
     public String formatLegacySymbols(@NotNull String text, @NotNull TabPlayer player, @NotNull Velocitab plugin) {
-        return LegacyComponentSerializer..legacySection()
+        return LegacyComponentSerializer.legacySection()
                 .serialize(format(text, player, plugin));
     }
     @NotNull

--- a/src/main/java/net/william278/velocitab/config/Formatter.java
+++ b/src/main/java/net/william278/velocitab/config/Formatter.java
@@ -80,6 +80,11 @@ public enum Formatter {
     }
 
     @NotNull
+    public String format(@NotNull String text) {
+        return text.replaceAll("&", "§");
+    }
+
+    @NotNull
     public String escape(@NotNull String text) {
         return escaper.apply(text);
     }

--- a/src/main/java/net/william278/velocitab/config/Formatter.java
+++ b/src/main/java/net/william278/velocitab/config/Formatter.java
@@ -80,10 +80,10 @@ public enum Formatter {
     }
 
     @NotNull
-    public String formatLegacySymbols(@NotNull String text) {
-        return text.replaceAll("&", "§");
+    public String formatLegacySymbols(@NotNull String text, @NotNull TabPlayer player, @NotNull Velocitab plugin) {
+        return LegacyComponentSerializer..legacySection()
+                .serialize(format(text, player, plugin));
     }
-
     @NotNull
     public String escape(@NotNull String text) {
         return escaper.apply(text);

--- a/src/main/java/net/william278/velocitab/config/Formatter.java
+++ b/src/main/java/net/william278/velocitab/config/Formatter.java
@@ -80,7 +80,7 @@ public enum Formatter {
     }
 
     @NotNull
-    public String format(@NotNull String text) {
+    public String formatLegacySymbols(@NotNull String text) {
         return text.replaceAll("&", "§");
     }
 

--- a/src/main/java/net/william278/velocitab/config/Placeholder.java
+++ b/src/main/java/net/william278/velocitab/config/Placeholder.java
@@ -65,6 +65,10 @@ public enum Placeholder {
         }
         final String replaced = format;
 
+        if(!replaced.matches("%.*?%")) {
+            return CompletableFuture.completedFuture(replaced);
+        }
+
         return plugin.getPAPIProxyBridgeHook()
                 .map(hook -> hook.formatPlaceholders(replaced, player.getPlayer()))
                 .orElse(CompletableFuture.completedFuture(replaced));

--- a/src/main/java/net/william278/velocitab/config/Placeholder.java
+++ b/src/main/java/net/william278/velocitab/config/Placeholder.java
@@ -65,7 +65,7 @@ public enum Placeholder {
         }
         final String replaced = format;
 
-        if(!replaced.matches("%.*?%")) {
+        if (!replaced.matches("%.*?%")) {
             return CompletableFuture.completedFuture(replaced);
         }
 

--- a/src/main/java/net/william278/velocitab/config/Settings.java
+++ b/src/main/java/net/william278/velocitab/config/Settings.java
@@ -59,6 +59,10 @@ public class Settings {
     @YamlKey("formats")
     private Map<String, String> formats = Map.of("default", "&7[%server%] &f%prefix%%username%");
 
+    @YamlKey("nametags")
+    @YamlComment("Nametag(s) to display above players' heads for each server group. To disable, set to empty")
+    private Map<String, String> nametags = Map.of("default", "&f%prefix%%username%&f%suffix%");
+
     @Getter
     @YamlComment("Which text formatter to use (MINEDOWN, MINIMESSAGE, or LEGACY)")
     @YamlKey("formatting_type")
@@ -162,6 +166,12 @@ public class Settings {
     public String getFormat(@NotNull String serverGroup) {
         return StringEscapeUtils.unescapeJava(
                 formats.getOrDefault(serverGroup, "%username%"));
+    }
+
+    @NotNull
+    public String getNametag(@NotNull String serverGroup) {
+        return StringEscapeUtils.unescapeJava(
+                nametags.getOrDefault(serverGroup, ""));
     }
 
     /**

--- a/src/main/java/net/william278/velocitab/config/Settings.java
+++ b/src/main/java/net/william278/velocitab/config/Settings.java
@@ -59,6 +59,7 @@ public class Settings {
     @YamlKey("formats")
     private Map<String, String> formats = Map.of("default", "&7[%server%] &f%prefix%%username%");
 
+    @Getter
     @YamlKey("nametags")
     @YamlComment("Nametag(s) to display above players' heads for each server group. To disable, set to empty")
     private Map<String, String> nametags = Map.of("default", "&f%prefix%%username%&f%suffix%");
@@ -172,6 +173,10 @@ public class Settings {
     public String getNametag(@NotNull String serverGroup) {
         return StringEscapeUtils.unescapeJava(
                 nametags.getOrDefault(serverGroup, ""));
+    }
+
+    public boolean areNametagsEnabled() {
+        return !nametags.isEmpty();
     }
 
     /**

--- a/src/main/java/net/william278/velocitab/hook/LuckPermsHook.java
+++ b/src/main/java/net/william278/velocitab/hook/LuckPermsHook.java
@@ -43,8 +43,7 @@ public class LuckPermsHook extends Hook {
 
     private int highestWeight = Role.DEFAULT_WEIGHT;
     private final LuckPerms api;
-    private final
-    EventSubscription<UserDataRecalculateEvent> event;
+    private final EventSubscription<UserDataRecalculateEvent> event;
 
     public LuckPermsHook(@NotNull Velocitab plugin) throws IllegalStateException {
         super(plugin);

--- a/src/main/java/net/william278/velocitab/hook/LuckPermsHook.java
+++ b/src/main/java/net/william278/velocitab/hook/LuckPermsHook.java
@@ -23,6 +23,7 @@ import com.velocitypowered.api.proxy.Player;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.cacheddata.CachedMetaData;
+import net.luckperms.api.event.EventSubscription;
 import net.luckperms.api.event.user.UserDataRecalculateEvent;
 import net.luckperms.api.model.group.Group;
 import net.luckperms.api.model.user.User;
@@ -42,11 +43,17 @@ public class LuckPermsHook extends Hook {
 
     private int highestWeight = Role.DEFAULT_WEIGHT;
     private final LuckPerms api;
+    private final
+    EventSubscription<UserDataRecalculateEvent> event;
 
     public LuckPermsHook(@NotNull Velocitab plugin) throws IllegalStateException {
         super(plugin);
         this.api = LuckPermsProvider.get();
-        api.getEventBus().subscribe(plugin, UserDataRecalculateEvent.class, this::onLuckPermsGroupUpdate);
+        event = api.getEventBus().subscribe(plugin, UserDataRecalculateEvent.class, this::onLuckPermsGroupUpdate);
+    }
+
+    public void close() {
+        event.close();
     }
 
     @NotNull

--- a/src/main/java/net/william278/velocitab/hook/LuckPermsHook.java
+++ b/src/main/java/net/william278/velocitab/hook/LuckPermsHook.java
@@ -87,6 +87,7 @@ public class LuckPermsHook extends Hook {
                             );
                             tabList.replacePlayer(updatedPlayer);
                             tabList.updatePlayer(updatedPlayer);
+                            tabList.updatePlayerDisplayName(updatedPlayer);
                         })
                         .delay(500, TimeUnit.MILLISECONDS)
                         .schedule());

--- a/src/main/java/net/william278/velocitab/hook/PAPIProxyBridgeHook.java
+++ b/src/main/java/net/william278/velocitab/hook/PAPIProxyBridgeHook.java
@@ -32,7 +32,7 @@ public class PAPIProxyBridgeHook extends Hook {
 
     public PAPIProxyBridgeHook(@NotNull Velocitab plugin) {
         super(plugin);
-        this.api = PlaceholderAPI.getInstance();
+        this.api = PlaceholderAPI.createInstance();
         this.api.setCacheExpiry(Math.max(0, plugin.getSettings().getPapiCacheTime()));
     }
 

--- a/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
+++ b/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
@@ -79,10 +79,8 @@ public class ScoreboardManager {
             return;
         }
 
-        String name = player.getUsername();
-
-        TabPlayer tabPlayer = plugin.getTabPlayer(player);
-
+        final String name = player.getUsername();
+        final TabPlayer tabPlayer = plugin.getTabPlayer(player);
         tabPlayer.getNametag(plugin).thenAccept(nametag -> {
             String[] split = nametag.split("%username%", 2);
             String prefix = split[0];

--- a/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
+++ b/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
@@ -109,8 +109,7 @@ public class ScoreboardManager {
             return;
         }
 
-        Optional<ServerConnection> optionalServerConnection = player.getCurrentServer();
-
+        final Optional<ServerConnection> optionalServerConnection = player.getCurrentServer();
         if (optionalServerConnection.isEmpty()) {
             return;
         }

--- a/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
+++ b/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
@@ -126,14 +126,12 @@ public class ScoreboardManager {
                 return;
             }
 
-            String role = createdTeams.getOrDefault(p.getUniqueId(), "");
-
+            final String role = createdTeams.getOrDefault(p.getUniqueId(), "");
             if (role.isEmpty()) {
                 return;
             }
 
-            String nametag = nametags.getOrDefault(role, "");
-
+            final String nametag = nametags.getOrDefault(role, "");
             if (nametag.isEmpty()) {
                 return;
             }

--- a/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
+++ b/src/main/java/net/william278/velocitab/packet/ScoreboardManager.java
@@ -82,7 +82,7 @@ public class ScoreboardManager {
         final String name = player.getUsername();
         final TabPlayer tabPlayer = plugin.getTabPlayer(player);
         tabPlayer.getNametag(plugin).thenAccept(nametag -> {
-            String[] split = nametag.split("%username%", 2);
+            String[] split = nametag.split(player.getUsername(), 2);
             String prefix = split[0];
             String suffix = split.length > 1 ? split[1] : "";
 

--- a/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
+++ b/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
@@ -141,32 +141,42 @@ public class UpdateTeamsPacket implements MinecraftPacket {
         return convertColorCharToInt(last.charAt(1));
     }
 
-    public static int convertColorCharToInt(char colorChar) {
-        return switch (colorChar) {
-            case '0' -> 0;
-            case '1' -> 1;
-            case '2' -> 2;
-            case '3' -> 3;
-            case '4' -> 4;
-            case '5' -> 5;
-            case '6' -> 6;
-            case '7' -> 7;
-            case '8' -> 8;
-            case '9' -> 9;
-            case 'a' -> 10;
-            case 'b' -> 11;
-            case 'c' -> 12;
-            case 'd' -> 13;
-            case 'e' -> 14;
-            case 'f' -> 15;
-            case 'k' -> 16; // Obfuscated
-            case 'l' -> 17; // Bold
-            case 'm' -> 18; // Strikethrough
-            case 'n' -> 19; // Underlined
-            case 'o' -> 20; // Italic
-            case 'r' -> 21; // Reset
-            default -> 15; // Invalid
-        };
+    public enum TeamColor {
+        BLACK('0', 0),
+        DARK_BLUE('1', 1),
+        DARK_GREEN('2', 2),
+        DARK_AQUA('3', 3),
+        DARK_RED('4', 4),
+        DARK_PURPLE('5', 5),
+        GOLD('6', 6),
+        GRAY('7', 7),
+        DARK_GRAY('8', 8),
+        BLUE('9', 9),
+        GREEN('a', 10),
+        AQUA('b', 11),
+        RED('c', 12),
+        LIGHT_PURPLE('d', 13),
+        YELLOW('e', 14),
+        WHITE('f', 15),
+        OBFUSCATED('k', 16),
+        BOLD('l', 17),
+        STRIKETHROUGH('m', 18),
+        UNDERLINED('n', 19),
+        ITALIC('o', 20),
+        RESET('r', 21);
+
+        private final char colorChar;
+        private final int id;
+
+        TeamColor(char colorChar, int id) {
+            this.colorChar= colorChar;
+            this.id = id;
+        }
+        
+        @NotNull
+        public static int getColorId(char char) {
+            return Arrays.stream(values()).filter(color -> color.colorChar == char).findFirst().orElse(15);
+        }
     }
 
     @Override

--- a/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
+++ b/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
@@ -62,21 +62,6 @@ public class UpdateTeamsPacket implements MinecraftPacket {
     }
 
     @NotNull
-    protected static UpdateTeamsPacket create(@NotNull Velocitab plugin, @NotNull String teamName, @NotNull String... teamMembers) {
-        return new UpdateTeamsPacket(plugin)
-                .teamName(teamName.length() > 16 ? teamName.substring(0, 16) : teamName)
-                .mode(UpdateMode.CREATE_TEAM)
-                .displayName(teamName)
-                .friendlyFlags(List.of(FriendlyFlag.CAN_HURT_FRIENDLY))
-                .nameTagVisibility(NameTagVisibility.ALWAYS)
-                .collisionRule(CollisionRule.ALWAYS)
-                .color(15)
-                .prefix("")
-                .suffix("")
-                .entities(Arrays.asList(teamMembers));
-    }
-
-    @NotNull
     protected static UpdateTeamsPacket create(@NotNull Velocitab plugin, @NotNull String teamName, @NotNull String displayName, @Nullable String prefix, @Nullable String suffix, @NotNull String... teamMembers) {
         return new UpdateTeamsPacket(plugin)
                 .teamName(teamName.length() > 16 ? teamName.substring(0, 16) : teamName)

--- a/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
+++ b/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
@@ -119,7 +119,7 @@ public class UpdateTeamsPacket implements MinecraftPacket {
         }
         int intvar = text.lastIndexOf("§");
 
-        if(intvar == -1 || intvar == text.length() - 1) {
+        if (intvar == -1 || intvar == text.length() - 1) {
             return 15;
         }
 

--- a/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
+++ b/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
@@ -138,7 +138,7 @@ public class UpdateTeamsPacket implements MinecraftPacket {
         }
 
         String last = text.substring(intvar, intvar + 2);
-        return convertColorCharToInt(last.charAt(1));
+        return TeamColor.getColorId(last.charAt(1));
     }
 
     public enum TeamColor {
@@ -173,9 +173,8 @@ public class UpdateTeamsPacket implements MinecraftPacket {
             this.id = id;
         }
         
-        @NotNull
-        public static int getColorId(char char) {
-            return Arrays.stream(values()).filter(color -> color.colorChar == char).findFirst().orElse(15);
+        public static int getColorId(char var) {
+            return Arrays.stream(values()).filter(color -> color.colorChar == var).map(c -> c.id).findFirst().orElse(15);
         }
     }
 

--- a/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
+++ b/src/main/java/net/william278/velocitab/packet/UpdateTeamsPacket.java
@@ -71,6 +71,35 @@ public class UpdateTeamsPacket implements MinecraftPacket {
     }
 
     @NotNull
+    protected static UpdateTeamsPacket create(@NotNull String teamName, @NotNull String displayName, @Nullable String prefix, @Nullable String suffix, @NotNull String... teamMembers) {
+        return new UpdateTeamsPacket()
+                .teamName(teamName.length() > 16 ? teamName.substring(0, 16) : teamName)
+                .mode(UpdateMode.CREATE_TEAM)
+                .displayName(getChatString(displayName))
+                .friendlyFlags(List.of(FriendlyFlag.CAN_HURT_FRIENDLY))
+                .nameTagVisibility(NameTagVisibility.ALWAYS)
+                .collisionRule(CollisionRule.ALWAYS)
+                .color(getLastColor(prefix))
+                .prefix(getChatString(prefix == null ? "" : prefix))
+                .suffix(getChatString(suffix == null ? "" : suffix))
+                .entities(Arrays.asList(teamMembers));
+    }
+
+    @NotNull
+    protected static UpdateTeamsPacket changeNameTag(@NotNull String teamName, @Nullable String prefix, @Nullable String suffix) {
+        return new UpdateTeamsPacket()
+                .teamName(teamName.length() > 16 ? teamName.substring(0, 16) : teamName)
+                .mode(UpdateMode.UPDATE_INFO)
+                .displayName(getChatString(teamName))
+                .friendlyFlags(List.of(FriendlyFlag.CAN_HURT_FRIENDLY))
+                .nameTagVisibility(NameTagVisibility.ALWAYS)
+                .collisionRule(CollisionRule.ALWAYS)
+                .color(getLastColor(prefix))
+                .prefix(getChatString(prefix == null ? "" : prefix))
+                .suffix(getChatString(suffix == null ? "" : suffix));
+    }
+
+    @NotNull
     protected static UpdateTeamsPacket addToTeam(@NotNull String teamName, @NotNull String... teamMembers) {
         return new UpdateTeamsPacket()
                 .teamName(teamName.length() > 16 ? teamName.substring(0, 16) : teamName)
@@ -87,8 +116,57 @@ public class UpdateTeamsPacket implements MinecraftPacket {
     }
 
     @NotNull
+    protected static UpdateTeamsPacket removeTeam(@NotNull String teamName) {
+        return new UpdateTeamsPacket()
+                .teamName(teamName.length() > 16 ? teamName.substring(0, 16) : teamName)
+                .mode(UpdateMode.REMOVE_TEAM);
+    }
+
+    @NotNull
     private static String getChatString(@NotNull String string) {
         return "{\"text\":\"" + StringEscapeUtils.escapeJson(string) + "\"}";
+    }
+
+    public static int getLastColor(@Nullable String text) {
+        if (text == null) {
+            return 15;
+        }
+        int intvar = text.lastIndexOf("§");
+
+        if(intvar == -1 || intvar == text.length() - 1) {
+            return 15;
+        }
+
+        String last = text.substring(intvar, intvar + 2);
+        return convertColorCharToInt(last.charAt(1));
+    }
+
+    public static int convertColorCharToInt(char colorChar) {
+        return switch (colorChar) {
+            case '0' -> 0;
+            case '1' -> 1;
+            case '2' -> 2;
+            case '3' -> 3;
+            case '4' -> 4;
+            case '5' -> 5;
+            case '6' -> 6;
+            case '7' -> 7;
+            case '8' -> 8;
+            case '9' -> 9;
+            case 'a' -> 10;
+            case 'b' -> 11;
+            case 'c' -> 12;
+            case 'd' -> 13;
+            case 'e' -> 14;
+            case 'f' -> 15;
+            case 'k' -> 16; // Obfuscated
+            case 'l' -> 17; // Bold
+            case 'm' -> 18; // Strikethrough
+            case 'n' -> 19; // Underlined
+            case 'o' -> 20; // Italic
+            case 'r' -> 21; // Reset
+            default -> 15; // Invalid
+        };
     }
 
     @Override

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -118,7 +118,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
     public CompletableFuture<String> getNametag(@NotNull Velocitab plugin) {
         final String serverGroup = plugin.getSettings().getServerGroup(getServerName());
         return Placeholder.replace(plugin.getSettings().getNametag(serverGroup), plugin, this)
-                .thenApply(formatted -> plugin.getFormatter().formatLegacySymbols(formatted)
+                .thenApply(formatted -> plugin.getFormatter().formatLegacySymbols(formatted, this, plugin)
                         .replace(player.getUsername(), "%username%"));
 
     }

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -118,8 +118,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
     public CompletableFuture<String> getNametag(@NotNull Velocitab plugin) {
         final String serverGroup = plugin.getSettings().getServerGroup(getServerName());
         return Placeholder.replace(plugin.getSettings().getNametag(serverGroup), plugin, this)
-                .thenApply(formatted -> plugin.getFormatter().formatLegacySymbols(formatted, this, plugin)
-                        .replace(player.getUsername(), "%username%"));
+                .thenApply(formatted -> plugin.getFormatter().formatLegacySymbols(formatted, this, plugin));
 
     }
 

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -20,6 +20,7 @@
 package net.william278.velocitab.player;
 
 import com.velocitypowered.api.proxy.Player;
+import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.william278.velocitab.Velocitab;
 import net.william278.velocitab.config.Placeholder;
@@ -36,8 +37,12 @@ public final class TabPlayer implements Comparable<TabPlayer> {
     private final Player player;
     private final Role role;
     private final int highestWeight;
+    @Getter
     private int headerIndex = 0;
+    @Getter
     private int footerIndex = 0;
+    @Getter
+    private Component lastDisplayname;
 
     public TabPlayer(@NotNull Player player, @NotNull Role role, int highestWeight) {
         this.player = player;
@@ -70,6 +75,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
 
     /**
      * Get the TAB server group this player is connected to
+     *
      * @param plugin instance of the {@link Velocitab} plugin
      * @return the name of the server group the player is on
      */
@@ -94,15 +100,15 @@ public final class TabPlayer implements Comparable<TabPlayer> {
     public CompletableFuture<Component> getDisplayName(@NotNull Velocitab plugin) {
         final String serverGroup = plugin.getSettings().getServerGroup(getServerName());
         return Placeholder.replace(plugin.getSettings().getFormat(serverGroup), plugin, this)
-                .thenApply(formatted -> plugin.getFormatter().format(formatted, this, plugin));
-
+                .thenApply(formatted -> plugin.getFormatter().format(formatted, this, plugin))
+                .thenApply(c -> this.lastDisplayname = c);
     }
 
     @NotNull
     public CompletableFuture<String> getNametag(@NotNull Velocitab plugin) {
         final String serverGroup = plugin.getSettings().getServerGroup(getServerName());
         return Placeholder.replace(plugin.getSettings().getNametag(serverGroup), plugin, this)
-                .thenApply(formatted -> plugin.getFormatter().format(formatted)
+                .thenApply(formatted -> plugin.getFormatter().formatLegacySymbols(formatted)
                         .replace(player.getUsername(), "%username%"));
 
     }
@@ -111,16 +117,14 @@ public final class TabPlayer implements Comparable<TabPlayer> {
     public String getTeamName(@NotNull Velocitab plugin) {
         return plugin.getSettings().getSortingElementList().stream()
                 .map(element -> element.resolve(this, plugin))
-                .collect(Collectors.joining("-")) + player.getUniqueId().toString().substring(0, 3);
+                .collect(Collectors.joining("-"))
+                + getPlayer().getUniqueId().toString().substring(0, 3);
     }
+
 
     public void sendHeaderAndFooter(@NotNull PlayerTabList tabList) {
         tabList.getHeader(this).thenAccept(header -> tabList.getFooter(this)
                 .thenAccept(footer -> player.sendPlayerListHeaderAndFooter(header, footer)));
-    }
-
-    public int getHeaderIndex() {
-        return headerIndex;
     }
 
     public void incrementHeaderIndex(@NotNull Velocitab plugin) {
@@ -128,10 +132,6 @@ public final class TabPlayer implements Comparable<TabPlayer> {
         if (headerIndex >= plugin.getSettings().getHeaderListSize(getServerGroup(plugin))) {
             headerIndex = 0;
         }
-    }
-
-    public int getFooterIndex() {
-        return footerIndex;
     }
 
     public void incrementFooterIndex(@NotNull Velocitab plugin) {

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -99,10 +99,19 @@ public final class TabPlayer implements Comparable<TabPlayer> {
     }
 
     @NotNull
+    public CompletableFuture<String> getNametag(@NotNull Velocitab plugin) {
+        final String serverGroup = plugin.getSettings().getServerGroup(getServerName());
+        return Placeholder.replace(plugin.getSettings().getNametag(serverGroup), plugin, this)
+                .thenApply(formatted -> plugin.getFormatter().format(formatted)
+                        .replace(player.getUsername(), "%username%"));
+
+    }
+
+    @NotNull
     public String getTeamName(@NotNull Velocitab plugin) {
         return plugin.getSettings().getSortingElementList().stream()
                 .map(element -> element.resolve(this, plugin))
-                .collect(Collectors.joining("-"));
+                .collect(Collectors.joining("-")) + player.getUniqueId().toString().substring(0, 3);
     }
 
     public void sendHeaderAndFooter(@NotNull PlayerTabList tabList) {

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -182,7 +182,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
                     ? String.format("%0" + Integer.toString(orderSize).length() + "d", position)
                     : String.valueOf(orderSize);
         }),
-        SERVER_GROUP_NAME((player, plugin) -> player.getServerGroup(plugin));
+        SERVER_GROUP_NAME(TabPlayer::getServerGroup);
 
         private final BiFunction<TabPlayer, Velocitab, String> elementResolver;
 

--- a/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
+++ b/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
@@ -36,9 +36,7 @@ import net.william278.velocitab.config.Placeholder;
 import net.william278.velocitab.player.TabPlayer;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -94,8 +92,6 @@ public class PlayerTabList {
         plugin.getServer().getScheduler()
                 .buildTask(plugin, () -> {
                     final TabList tabList = joined.getTabList();
-                    final Map<String, String> playerRoles = new HashMap<>();
-
                     for (TabPlayer player : players) {
                         // Skip players on other servers if the setting is enabled
                         if (plugin.getSettings().isOnlyListPlayersInSameGroup() && serversInGroup.isPresent()
@@ -103,7 +99,6 @@ public class PlayerTabList {
                             continue;
                         }
 
-                        playerRoles.put(player.getPlayer().getUsername(), player.getTeamName(plugin));
                         tabList.getEntries().stream()
                                 .filter(e -> e.getProfile().getId().equals(player.getPlayer().getUniqueId())).findFirst()
                                 .ifPresentOrElse(


### PR DESCRIPTION
Added support for custom nametags. Due to minecraft limit only legacy chatcolors are supported. Team names are now unique, so 1 team can have max 1 player. Fixed problem with luckperms event bus while reloading the plugin. Added regex check for placeholders to avoid useless requests.