### PR TITLE
Add sorting by server group

### DIFF
--- a/docs/Sorting.md
+++ b/docs/Sorting.md
@@ -17,11 +17,13 @@ sort_players_by:
 ### List of elements
 The following sorting elements are supported:
 
-| Sorting element | Description                                        |
-|:---------------:|----------------------------------------------------|
-|  `ROLE_WEIGHT`  | The weight of the player's primary LuckPerms group |
-|   `ROLE_NAME`   | The name of the player's primary LuckPerms group   |
-|  `SERVER_NAME`  | The name of the server the player is connected to  |
+|   Sorting element   | Description                                             |
+|:-------------------:|---------------------------------------------------------|
+|    `ROLE_WEIGHT`    | The weight of the player's primary LuckPerms group      |
+|     `ROLE_NAME`     | The name of the player's primary LuckPerms group        |
+|    `SERVER_NAME`    | The name of the server the player is connected to       |
+|   `SERVER_GROUP`    | The order in which the groups are designated            |
+| `SERVER_GROUP_NAME` | The name of the server group the player is connected to |
 
 ## Technical details
 In Minecraft, the TAB list is sorted by the client; the server does not handle the actual display order of names in the list. Players are sorted first by the name of their scoreboard team, then by their name. This is why having a proxy TAB plugin sort players is a surprisingly complex feature request!

--- a/src/main/java/net/william278/velocitab/config/Settings.java
+++ b/src/main/java/net/william278/velocitab/config/Settings.java
@@ -28,6 +28,7 @@ import net.william278.velocitab.player.TabPlayer;
 import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -66,8 +67,8 @@ public class Settings {
 
     @Getter
     @YamlKey("server_groups")
-    @YamlComment("The servers in each group of servers")
-    private Map<String, List<String>> serverGroups = Map.of("default", List.of("lobby1", "lobby2", "lobby3"));
+    @YamlComment("The servers in each group of servers. The order of groups is important when sorting by SERVER_GROUP.")
+    private LinkedHashMap<String, List<String>> serverGroups = new LinkedHashMap<>(Map.of("default", List.of("lobby1", "lobby2", "lobby3")));
 
     @Getter
     @YamlKey("fallback_enabled")
@@ -92,11 +93,6 @@ public class Settings {
     private Map<String, String> serverDisplayNames = Map.of("very-long-server-name", "VLSN");
 
     @Getter
-    @YamlKey("server_group_order")
-    @YamlComment("Define order of server groups for sorting.")
-    private List<String> serverGroupOrder = List.of("default");
-
-    @Getter
     @YamlKey("enable_papi_hook")
     @YamlComment("Whether to enable the PAPIProxyBridge hook for PAPI support")
     private boolean enablePapiHook = true;
@@ -118,7 +114,7 @@ public class Settings {
 
     @YamlKey("sort_players_by")
     @YamlComment("Ordered list of elements by which players should be sorted. " +
-            "(ROLE_WEIGHT, ROLE_NAME and SERVER_NAME are supported)")
+            "(ROLE_WEIGHT, ROLE_NAME, SERVER_NAME, SERVER_GROUP and SERVER_GROUP_NAME are supported)")
     private List<String> sortPlayersBy = List.of(
             TabPlayer.SortableElement.ROLE_WEIGHT.name(),
             TabPlayer.SortableElement.ROLE_NAME.name()
@@ -132,9 +128,9 @@ public class Settings {
     private int updateRate = 0;
 
     public Settings(@NotNull Velocitab plugin) {
-        this.serverGroups = Map.of("default",
+        this.serverGroups = new LinkedHashMap<>(Map.of("default",
                 plugin.getServer().getAllServers().stream().map(server -> server.getServerInfo().getName()).toList()
-        );
+        ));
     }
 
     @SuppressWarnings("unused")
@@ -187,7 +183,7 @@ public class Settings {
      * @return The ordinal position of the server group
      */
     public int getServerGroupPosition(@NotNull String serverGroupName) {
-        return serverGroupOrder.indexOf(serverGroupName);
+        return List.copyOf(serverGroups.keySet()).indexOf(serverGroupName);
     }
 
     /**

--- a/src/main/java/net/william278/velocitab/config/Settings.java
+++ b/src/main/java/net/william278/velocitab/config/Settings.java
@@ -92,6 +92,11 @@ public class Settings {
     private Map<String, String> serverDisplayNames = Map.of("very-long-server-name", "VLSN");
 
     @Getter
+    @YamlKey("server_group_order")
+    @YamlComment("Define order of server groups for sorting.")
+    private List<String> serverGroupOrder = List.of("default");
+
+    @Getter
     @YamlKey("enable_papi_hook")
     @YamlComment("Whether to enable the PAPIProxyBridge hook for PAPI support")
     private boolean enablePapiHook = true;
@@ -173,6 +178,16 @@ public class Settings {
     @NotNull
     public String getServerDisplayName(@NotNull String serverName) {
         return serverDisplayNames.getOrDefault(serverName, serverName);
+    }
+
+    /**
+     * Get the ordinal position of the server group
+     *
+     * @param serverGroupName The server group name
+     * @return The ordinal position of the server group
+     */
+    public int getServerGroupPosition(@NotNull String serverGroupName) {
+        return serverGroupOrder.indexOf(serverGroupName);
     }
 
     /**

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -79,6 +79,15 @@ public final class TabPlayer implements Comparable<TabPlayer> {
     }
 
     /**
+     * Get the ordinal position of the TAB server group this player is connected to
+     * @param plugin instance of the {@link Velocitab} plugin
+     * @return The ordinal position of the server group
+     */
+    public int getServerGroupPosition(@NotNull Velocitab plugin) {
+        return plugin.getSettings().getServerGroupPosition(getServerGroup(plugin));
+    }
+
+    /**
      * Get the display name of the server the player is currently on.
      * Affected by server aliases defined in the config.
      *
@@ -155,7 +164,9 @@ public final class TabPlayer implements Comparable<TabPlayer> {
         ROLE_NAME((player, plugin) -> player.getRole().getName()
                 .map(name -> name.length() > 3 ? name.substring(0, 3) : name)
                 .orElse("")),
-        SERVER_NAME((player, plugin) -> player.getServerName());
+        SERVER_NAME((player, plugin) -> player.getServerName()),
+        SERVER_GROUP((player, plugin) -> String.valueOf(player.getServerGroupPosition(plugin))),
+        SERVER_GROUP_NAME((player, plugin) -> player.getServerGroup(plugin));
 
         private final BiFunction<TabPlayer, Velocitab, String> elementResolver;
 

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -168,7 +168,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
                 .orElse("")),
         SERVER_NAME((player, plugin) -> player.getServerName()),
         SERVER_GROUP((player, plugin) -> {
-            int orderSize = plugin.getSettings().getServerGroupOrder().size();
+            int orderSize = plugin.getSettings().getServerGroups().size();
             int position = player.getServerGroupPosition(plugin);
             return position >= 0
                     ? String.format("%0" + Integer.toString(orderSize).length() + "d", position)

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -70,6 +70,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
 
     /**
      * Get the TAB server group this player is connected to
+     *
      * @param plugin instance of the {@link Velocitab} plugin
      * @return the name of the server group the player is on
      */
@@ -80,6 +81,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
 
     /**
      * Get the ordinal position of the TAB server group this player is connected to
+     *
      * @param plugin instance of the {@link Velocitab} plugin
      * @return The ordinal position of the server group
      */
@@ -165,7 +167,13 @@ public final class TabPlayer implements Comparable<TabPlayer> {
                 .map(name -> name.length() > 3 ? name.substring(0, 3) : name)
                 .orElse("")),
         SERVER_NAME((player, plugin) -> player.getServerName()),
-        SERVER_GROUP((player, plugin) -> String.valueOf(player.getServerGroupPosition(plugin))),
+        SERVER_GROUP((player, plugin) -> {
+            int orderSize = plugin.getSettings().getServerGroupOrder().size();
+            int position = player.getServerGroupPosition(plugin);
+            return position >= 0
+                    ? String.format("%0" + Integer.toString(orderSize).length() + "d", position)
+                    : orderSize + player.getServerGroup(plugin);
+        }),
         SERVER_GROUP_NAME((player, plugin) -> player.getServerGroup(plugin));
 
         private final BiFunction<TabPlayer, Velocitab, String> elementResolver;

--- a/src/main/java/net/william278/velocitab/player/TabPlayer.java
+++ b/src/main/java/net/william278/velocitab/player/TabPlayer.java
@@ -172,7 +172,7 @@ public final class TabPlayer implements Comparable<TabPlayer> {
             int position = player.getServerGroupPosition(plugin);
             return position >= 0
                     ? String.format("%0" + Integer.toString(orderSize).length() + "d", position)
-                    : orderSize + player.getServerGroup(plugin);
+                    : String.valueOf(orderSize);
         }),
         SERVER_GROUP_NAME((player, plugin) -> player.getServerGroup(plugin));
 


### PR DESCRIPTION
- Added two new sorting elements: `SERVER_GROUP` and `SERVER_GROUP_NAME`

`SERVER_GROUP` sorts by the order of groups in `server_groups`.

For example with the following configuration:
```yaml
server_groups:
  lobbies:
  - lobby1
  - lobby2
  survival:
  - survival
  creative:
  - creative
  minigames:
  - bedwars
  - skyblock
```

Order of the groups would be: `lobbies, survival, creative, minigames, <other servers>...`