### PR TITLE
Add all possible ProtocolVersions to Protocol403Adapter

### DIFF
--- a/src/main/java/net/william278/velocitab/packet/Protocol403Adapter.java
+++ b/src/main/java/net/william278/velocitab/packet/Protocol403Adapter.java
@@ -30,18 +30,35 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Adapter for handling the UpdateTeamsPacket for Minecraft 1.13+
+ * Adapter for handling the UpdateTeamsPacket for Minecraft 1.13.2+
  */
 @SuppressWarnings("DuplicatedCode")
 public class Protocol403Adapter extends TeamsPacketAdapter {
 
     public Protocol403Adapter() {
         super(Set.of(ProtocolVersion.MINECRAFT_1_13_2,
+                ProtocolVersion.MINECRAFT_1_14,
+                ProtocolVersion.MINECRAFT_1_14_1,
+                ProtocolVersion.MINECRAFT_1_14_2,
+                ProtocolVersion.MINECRAFT_1_14_3,
                 ProtocolVersion.MINECRAFT_1_14_4,
+                ProtocolVersion.MINECRAFT_1_15,
+                ProtocolVersion.MINECRAFT_1_15_1,
                 ProtocolVersion.MINECRAFT_1_15_2,
+                ProtocolVersion.MINECRAFT_1_16,
+                ProtocolVersion.MINECRAFT_1_16_1,
+                ProtocolVersion.MINECRAFT_1_16_2,
+                ProtocolVersion.MINECRAFT_1_16_3,
                 ProtocolVersion.MINECRAFT_1_16_4,
+                ProtocolVersion.MINECRAFT_1_17,
                 ProtocolVersion.MINECRAFT_1_17_1,
+                ProtocolVersion.MINECRAFT_1_18,
+                //ProtocolVersion.MINECRAFT_1_18_1,
                 ProtocolVersion.MINECRAFT_1_18_2,
+                ProtocolVersion.MINECRAFT_1_19,
+                ProtocolVersion.MINECRAFT_1_19_1,
+                //ProtocolVersion.MINECRAFT_1_19_2,
+                ProtocolVersion.MINECRAFT_1_19_3,
                 ProtocolVersion.MINECRAFT_1_19_4,
                 ProtocolVersion.MINECRAFT_1_20,
                 ProtocolVersion.MINECRAFT_1_20_2


### PR DESCRIPTION
This fixes 1.19.2 clients (and likely all other relevant versions) being instantly kicked with the following error when connecting to the proxy:

```
[Netty epoll Worker #8/ERROR] [com.velocitypowered.proxy.connection.MinecraftConnection]: [connected player] PLAYER (/<redacted>): exception encountered in com.velocitypowered.proxy.connection.client.ClientPlaySessionHandler@de4b80c
io.netty.handler.codec.EncoderException: java.lang.IllegalArgumentException: No adapter found for protocol version 1.19.1
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:125) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:881) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite(AbstractChannelHandlerContext.java:863) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:968) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:856) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.github._4drian3d.vpacketevents.plugin.PlayerChannelHandler.write(PlayerChannelHandler.java:67) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:879) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:940) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1247) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:403) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: java.lang.IllegalArgumentException: No adapter found for protocol version 1.19.1
	at net.william278.velocitab.packet.ScoreboardManager.lambda$getPacketAdapter$1(ScoreboardManager.java:66) ~[?:?]
	at java.util.Optional.orElseThrow(Optional.java:403) ~[?:?]
	at net.william278.velocitab.packet.ScoreboardManager.getPacketAdapter(ScoreboardManager.java:66) ~[?:?]
	at net.william278.velocitab.packet.UpdateTeamsPacket.encode(UpdateTeamsPacket.java:180) ~[?:?]
	at com.velocitypowered.proxy.protocol.netty.MinecraftEncoder.encode(MinecraftEncoder.java:54) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at com.velocitypowered.proxy.protocol.netty.MinecraftEncoder.encode(MinecraftEncoder.java:32) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107) ~[velocity-3.2.0-SNAPSHOT-265.jar:3.2.0-SNAPSHOT (git-19abb909-b265)]
	... 17 more
[Netty epoll Worker #8/INFO] [com.velocitypowered.proxy.connection.MinecraftConnection]: [server connection] PLAYER -> SERVER has disconnected
```