### PR TITLE
Add an option to ignore build version check

### DIFF
--- a/src/main/java/net/william278/velocitab/config/Metadata.java
+++ b/src/main/java/net/william278/velocitab/config/Metadata.java
@@ -37,6 +37,7 @@ public class Metadata {
 
     private String velocityApiVersion;
     private int velocityMinimumBuild;
+    private boolean ignoreBuildVersion;
 
     public void validateApiVersion(@NotNull Version version) {
         if (version.compareTo(Version.fromString(velocityApiVersion)) < 0) {
@@ -48,6 +49,10 @@ public class Metadata {
     }
 
     public void validateBuild(@NotNull Version version) {
+        if (ignoreBuildVersion) {
+            return;
+        }
+
         int serverBuild = getBuildNumber(version.toString());
         if (serverBuild < velocityMinimumBuild) {
             throw new IllegalStateException("Your Velocity build version (#" + serverBuild + ") is not supported! " +

--- a/src/main/resources/metadata.yml
+++ b/src/main/resources/metadata.yml
@@ -1,2 +1,3 @@
 velocity_api_version: '${velocity_api_version}'
 velocity_minimum_build: ${velocity_minimum_build}
+ignore_build_version: false


### PR DESCRIPTION
It would be beneficial it there would be an option to ignore build version check, as some of open-source forks such as [Velocity-CTD](https://github.com/GemstoneGG/Velocity-CTD) doesn't include build version, so plugin won't start there, due to no matches in [regex](https://github.com/WiIIiam278/Velocitab/blob/b4746dd483e7040dec3fe5acb04afc5ddd4592ff/src/main/java/net/william278/velocitab/config/Metadata.java#L60).