### PR TITLE
fix: tablist continuously shows on disabled server

### DIFF
--- a/src/main/java/net/william278/velocitab/tab/TabListListener.java
+++ b/src/main/java/net/william278/velocitab/tab/TabListListener.java
@@ -93,7 +93,7 @@ public class TabListListener {
 
         // Get the group the player should now be in
         final @NotNull Optional<Group> groupOptional = tabList.getGroup(serverName);
-        final boolean isDefault = groupOptional.map(g -> g.isDefault(plugin)).orElse(false);
+        final boolean isDefault = groupOptional.map(g -> g.isDefault(plugin)).orElse(true);
 
         // Removes cached relational data of the joined player from all other players
         plugin.getTabList().clearCachedData(joined);


### PR DESCRIPTION
```
If the server is not in a group, use fallback.
If fallback is disabled, permit the player to switch excluded servers without a header or footer override
```

By this quote, isDefault condition should returns `true` when the server is not in any group, so the checks

`isDefault && !plugin.getSettings().isFallbackEnabled() && !groupOptional.map(g -> g.containsServer(plugin, serverName)).orElse(false)` can be true and remove player from tablist
