### PR TITLE
fix: increment indexes on header/footer update

### DIFF
--- a/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
+++ b/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
@@ -424,7 +424,10 @@ public class PlayerTabList {
     }
 
     public void updateHeaderFooter(@NotNull Group group) {
-        group.getTabPlayers(plugin).forEach(p -> p.sendHeaderAndFooter(this));
+        group.getTabPlayers(plugin).forEach(p -> {
+            p.incrementIndexes();
+            p.sendHeaderAndFooter(this);
+        });
     }
 
     // Update a player's name in the tab list and scoreboard team


### PR DESCRIPTION
#248 introduced a bug where the header/footer index is not updated when called from `updatePeriodically`, leading to a static header and footer.

This change will call `TabPlayer::sendHeaderAndFooter` prior to sending the header and footer in the `updateHeaderFooter` method, which is called by the `updatePeriodically` task. 