### PR TITLE
Fix: Apply placeholder replacement when placeholder is not found

### DIFF
--- a/src/main/java/net/william278/velocitab/placeholder/PlaceholderManager.java
+++ b/src/main/java/net/william278/velocitab/placeholder/PlaceholderManager.java
@@ -237,11 +237,9 @@ public class PlaceholderManager {
             String replacementToAppend = null;
 
             if (groupReplacements.containsKey(placeholder)) {
-                final String currentValue = parsed.get(placeholder);
+                final String currentValue = parsed.getOrDefault(placeholder, placeholder);
                 if (currentValue != null) {
                     replacementToAppend = getReplacement(player.getGroup(), placeholder, currentValue);
-                } else {
-                    replacementToAppend = getReplacement(player.getGroup(), placeholder, placeholder);
                 }
             }
 

--- a/src/main/java/net/william278/velocitab/placeholder/PlaceholderManager.java
+++ b/src/main/java/net/william278/velocitab/placeholder/PlaceholderManager.java
@@ -240,6 +240,8 @@ public class PlaceholderManager {
                 final String currentValue = parsed.get(placeholder);
                 if (currentValue != null) {
                     replacementToAppend = getReplacement(player.getGroup(), placeholder, currentValue);
+                } else {
+                    replacementToAppend = getReplacement(player.getGroup(), placeholder, placeholder);
                 }
             }
 


### PR DESCRIPTION
Previously, if a placeholder (e.g., %essentials_afk%) was not resolved (i.e., had no current value), the system would not apply any specific replacement rules defined for the placeholder string itself. This meant that a configuration like:

placeholder_replacements:
  '%essentials_afk%':
    - placeholder: '%essentials_afk%' replacement: "Not present"

would not result in "%essentials_afk%" being replaced by "Not present" if the %essentials_afk% placeholder didn't resolve.