### PR TITLE
Always showing hats

### DIFF
--- a/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
+++ b/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
@@ -344,6 +344,7 @@ public class PlayerTabList {
                 .displayName(displayName)
                 .latency(Math.max((int) player.getPlayer().getPing(), 0))
                 .tabList(tabList)
+                .showHat(true)
                 .build();
     }
 
@@ -361,6 +362,7 @@ public class PlayerTabList {
                 .displayName(displayName)
                 .latency(Math.max((int) player.getPlayer().getPing(), 0))
                 .tabList(tabList)
+                .showHat(true)
                 .build();
     }
 


### PR DESCRIPTION
In version 1.21.4 and later, Velocity allows the hat to be shown even if the player isn't nearby.