### PR TITLE
Fix MiniPlaceholders relational tags

### DIFF
--- a/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
+++ b/src/main/java/net/william278/velocitab/tab/PlayerTabList.java
@@ -596,7 +596,7 @@ public class PlayerTabList {
 
             final String withPlaceholders = plugin.getPlaceholderManager().applyViewerPlaceholders(viewer, formatConditionalPlaceholders);
             final String unformatted = plugin.getPlaceholderManager().formatVelocitabPlaceholders(withPlaceholders, tabPlayer, viewer);
-            final Component displayNameComponent = formatComponent(tabPlayer, unformatted);
+            final Component displayNameComponent = formatRelationalComponent(tabPlayer, viewer, unformatted);
             updateEntryDisplayName(tabPlayer, viewer, displayNameComponent);
         });
     }


### PR DESCRIPTION
`PlayerTabList#updateRelationalDisplayName` uses `formatComponent` instead of `formatRelationalComponent`, dropping the viewer before it reaches `MiniPlaceholdersHook`. As a result, MiniPlaceholders relational tags are never resolved on periodic format updates.